### PR TITLE
Inspect assumes keys to be string, but our code passes FixNum keys, addi...

### DIFF
--- a/lib/riak/robject.rb
+++ b/lib/riak/robject.rb
@@ -179,7 +179,7 @@ module Riak
     # @return [String] A representation suitable for IRB and debugging output
     def inspect
       body = @siblings.map {|s| s.inspect }.join(", ")
-      "#<#{self.class.name} {#{bucket.name}#{"," + @key if @key}} [#{body}]>"
+      "#<#{self.class.name} {#{bucket.name}#{"," + @key.to_s if @key}} [#{body}]>"
     end
 
     # Walks links from this object to other objects in Riak.


### PR DESCRIPTION
...ng .to_s
